### PR TITLE
Set up debug/verbose logging configuration

### DIFF
--- a/lib/screens/debug_settings_screen.dart
+++ b/lib/screens/debug_settings_screen.dart
@@ -93,7 +93,8 @@ class _DebugSettingsScreenState extends State<DebugSettingsScreen> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Verbose logging ${enabled ? 'enabled' : 'disabled'}'),
+            content:
+                Text('Verbose logging ${enabled ? 'enabled' : 'disabled'}'),
             backgroundColor: enabled ? Colors.green : Colors.orange,
           ),
         );

--- a/lib/services/app_settings_service.dart
+++ b/lib/services/app_settings_service.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Service for managing application settings and preferences
 class AppSettingsService {
   static const String _debugLoggingKey = 'debug_logging_enabled';
+  static const String _verboseLoggingKey = 'verbose_logging_enabled';
   static const String _debugModeKey = 'debug_mode_enabled';
 
   late SharedPreferences _prefs;
@@ -20,6 +21,16 @@ class AppSettingsService {
   /// Enable or disable debug logging
   Future<void> setDebugLoggingEnabled(bool enabled) async {
     await _prefs.setBool(_debugLoggingKey, enabled);
+  }
+
+  /// Check if verbose logging is enabled
+  Future<bool> isVerboseLoggingEnabled() async {
+    return _prefs.getBool(_verboseLoggingKey) ?? false;
+  }
+
+  /// Enable or disable verbose logging
+  Future<void> setVerboseLoggingEnabled(bool enabled) async {
+    await _prefs.setBool(_verboseLoggingKey, enabled);
   }
 
   /// Check if debug mode is enabled in app settings


### PR DESCRIPTION
This pull request adds a new "Verbose Logging" option to the app's debug settings, allowing for more granular control over log output. The implementation involves updates to the settings UI, persistence layer, and logging service, as well as some refactoring and cleanup of logging methods.

**New verbose logging feature and logging improvements:**

* Added a "Verbose Logging" toggle to the `DebugSettingsScreen`, including UI, state management, and user feedback via snackbars. [[1]](diffhunk://#diff-e72f95b6068b7ee791a5801e38e6a67921867f1248da29577d4abe0ab522e18fR20) [[2]](diffhunk://#diff-e72f95b6068b7ee791a5801e38e6a67921867f1248da29577d4abe0ab522e18fR33-R37) [[3]](diffhunk://#diff-e72f95b6068b7ee791a5801e38e6a67921867f1248da29577d4abe0ab522e18fR81-R113) [[4]](diffhunk://#diff-e72f95b6068b7ee791a5801e38e6a67921867f1248da29577d4abe0ab522e18fL237-R285)
* Updated `AppSettingsService` to persist the verbose logging setting, with new methods to get/set its value. [[1]](diffhunk://#diff-71a11e88adec9a902049526a3dcbde2613b9d39877f3548aa2db6f340cfc4836R6) [[2]](diffhunk://#diff-71a11e88adec9a902049526a3dcbde2613b9d39877f3548aa2db6f340cfc4836R26-R35)
* Enhanced `LoggingService` to support the verbose logging level, including:
  - Initialization logic that checks both debug and verbose logging settings. [[1]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aR26-R41) [[2]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL50-R115)
  - A new `_determineLogLevel` helper to set the minimum log level based on the toggles.
  - Methods to update logging configuration dynamically when toggles change.
  - Addition of a `verbose` log method and improved log level handling.

**Refactoring and cleanup of logging methods:**

* Simplified logging method signatures by removing unused `data` parameters and making signatures more consistent throughout `LoggingService`. [[1]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL89-R138) [[2]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL106-R174) [[3]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL138-R187) [[4]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL153-R196) [[5]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL162-R214) [[6]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL180-R254) [[7]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL219-R263) [[8]](diffhunk://#diff-89c5bc5ffa6d5edcff28b511698c07884d49476c4930a482a7d3a53d6623e63aL228-R276)

These changes provide users and developers with finer control over log verbosity and modernize the logging codebase for maintainability.

Fixes #51