### PR TITLE
Run CI checks on PR and deploy on main commit

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,10 +6,11 @@
 name: Dart
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+env:
+  FLUTTER_VERSION: '3.32.x'
 
 jobs:
   build:
@@ -21,7 +22,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.32.x'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,38 +32,8 @@ env:
   FLUTTER_VERSION: '3.32.x'
 
 jobs:
-  # Job 0: Run CI checks first
-  ci-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          cache: true
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Analyze project source
-        run: flutter analyze --fatal-infos
-
-      - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
-        
-      - name: Run tests
-        run: flutter test --coverage
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage/lcov.info
-
   # Job 1: Build and deploy web version
   deploy-web:
-    needs: ci-checks
     if: github.event_name == 'push' || github.event.inputs.deploy_target == 'web' || github.event.inputs.deploy_target == 'all'
     runs-on: ubuntu-latest
     permissions:
@@ -118,7 +88,6 @@ jobs:
 
   # Job 2: Build Android APK
   build-android:
-    needs: ci-checks
     if: github.event_name == 'release' || github.event.inputs.deploy_target == 'android' || github.event.inputs.deploy_target == 'all'
     runs-on: ubuntu-latest
     
@@ -191,7 +160,6 @@ jobs:
 
   # Job 3: Build Windows executable
   build-windows:
-    needs: ci-checks
     if: github.event_name == 'release' || github.event.inputs.deploy_target == 'windows' || github.event.inputs.deploy_target == 'all'
     runs-on: windows-latest
     


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for Dart and deployment. The main changes involve improving environment variable handling for the Flutter version and simplifying the deployment workflow by removing the separate CI checks job.

**Workflow improvements:**

* Moved the `FLUTTER_VERSION` environment variable to the top-level `env` section in `.github/workflows/dart.yml` and updated the Flutter setup step to use this variable. [[1]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aL9-R14) [[2]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aL24-R25)
* Removed the `ci-checks` job from `.github/workflows/deploy.yml`, along with its dependencies from the `deploy-web`, `build-android`, and `build-windows` jobs, streamlining the deployment process. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L35-L66) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L121) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L194)