### PR TITLE
Add debug logging for setting meta theme color in WebThemeHelper

### DIFF
--- a/lib/utils/web_theme_helper_web.dart
+++ b/lib/utils/web_theme_helper_web.dart
@@ -9,6 +9,9 @@ class WebThemeHelper {
       if (!kIsWeb) {
         return; // Safety check to ensure this runs only on web
       }
+
+      LoggingService.debug('Setting meta theme color to $hexColor');
+
       // Remove existing theme-color meta tags
       final existingTags =
           web.document.querySelectorAll('meta[name="theme-color"]');


### PR DESCRIPTION
This pull request adds a debug log to the process of setting the meta theme color in the `WebThemeHelper` class. This change helps track when the theme color is updated, making it easier to debug and monitor UI changes.

Logging improvements:

* Added a call to `LoggingService.debug` to log when the meta theme color is set in `web_theme_helper_web.dart`.