### PR TITLE
feat: Unify exercise notes and user preferences notes

### DIFF
--- a/lib/models/user_exercise_preferences.dart
+++ b/lib/models/user_exercise_preferences.dart
@@ -5,7 +5,7 @@ import 'package:flutter_lifter/utils/utils.dart';
 /// Used to customize default exercises without modifying the immutable originals.
 ///
 /// Supports user notes and photos with cloud sync preparation:
-/// - [userNotes]: Rich personal notes (separate from quick tips in [notes])
+/// - [userNotes]: Rich personal notes
 /// - [localPhotoPaths]: Paths to locally stored photos
 /// - [cloudPhotoUrls]: URLs of photos synced to cloud storage
 /// - [pendingPhotoUploads]: Local paths awaiting cloud upload
@@ -26,9 +26,6 @@ class UserExercisePreferences {
 
   /// User's preferred rest time in seconds (overrides exercise.defaultRestTimeSeconds)
   final int? preferredRestTimeSeconds;
-
-  /// User's personal notes for this exercise (quick tips)
-  final String? notes;
 
   /// User's detailed personal notes for this exercise (form cues, tips, etc.)
   final String? userNotes;
@@ -56,7 +53,6 @@ class UserExercisePreferences {
     this.preferredReps,
     this.preferredWeight,
     this.preferredRestTimeSeconds,
-    this.notes,
     this.userNotes,
     List<String>? localPhotoPaths,
     List<String>? cloudPhotoUrls,
@@ -74,7 +70,6 @@ class UserExercisePreferences {
     int? preferredReps,
     double? preferredWeight,
     int? preferredRestTimeSeconds,
-    String? notes,
     String? userNotes,
     List<String>? localPhotoPaths,
     List<String>? cloudPhotoUrls,
@@ -88,7 +83,6 @@ class UserExercisePreferences {
       preferredReps: preferredReps,
       preferredWeight: preferredWeight,
       preferredRestTimeSeconds: preferredRestTimeSeconds,
-      notes: notes,
       userNotes: userNotes,
       localPhotoPaths: localPhotoPaths,
       cloudPhotoUrls: cloudPhotoUrls,
@@ -104,7 +98,6 @@ class UserExercisePreferences {
       preferredReps != null ||
       preferredWeight != null ||
       preferredRestTimeSeconds != null ||
-      notes != null ||
       userNotes != null ||
       localPhotoPaths.isNotEmpty ||
       cloudPhotoUrls.isNotEmpty;
@@ -132,7 +125,6 @@ class UserExercisePreferences {
       defaultWeight: preferredWeight ?? exercise.defaultWeight,
       defaultRestTimeSeconds:
           preferredRestTimeSeconds ?? exercise.defaultRestTimeSeconds,
-      notes: notes ?? exercise.notes,
     );
   }
 
@@ -150,7 +142,6 @@ class UserExercisePreferences {
     int? preferredReps,
     double? preferredWeight,
     int? preferredRestTimeSeconds,
-    String? notes,
     String? userNotes,
     List<String>? localPhotoPaths,
     List<String>? cloudPhotoUrls,
@@ -166,7 +157,6 @@ class UserExercisePreferences {
       preferredWeight: preferredWeight ?? this.preferredWeight,
       preferredRestTimeSeconds:
           preferredRestTimeSeconds ?? this.preferredRestTimeSeconds,
-      notes: notes ?? this.notes,
       userNotes: userNotes ?? this.userNotes,
       localPhotoPaths: localPhotoPaths ?? this.localPhotoPaths,
       cloudPhotoUrls: cloudPhotoUrls ?? this.cloudPhotoUrls,
@@ -218,7 +208,6 @@ class UserExercisePreferences {
       preferredReps: json['preferredReps'],
       preferredWeight: json['preferredWeight']?.toDouble(),
       preferredRestTimeSeconds: json['preferredRestTimeSeconds'],
-      notes: json['notes'],
       userNotes: json['userNotes'],
       localPhotoPaths:
           (json['localPhotoPaths'] as List<dynamic>?)
@@ -253,7 +242,6 @@ class UserExercisePreferences {
       'preferredReps': preferredReps,
       'preferredWeight': preferredWeight,
       'preferredRestTimeSeconds': preferredRestTimeSeconds,
-      'notes': notes,
       'userNotes': userNotes,
       'localPhotoPaths': localPhotoPaths,
       'cloudPhotoUrls': cloudPhotoUrls,

--- a/lib/screens/create_exercise_screen.dart
+++ b/lib/screens/create_exercise_screen.dart
@@ -117,6 +117,8 @@ class _CreateExerciseScreenState extends ConsumerState<CreateExerciseScreen> {
       // Load user preferences to populate notes from userNotes if available
       // (the unified notes field may have been edited from the detail view)
       final prefs = await repository.getPreferenceForExercise(exercise.id);
+      if (!mounted) return;
+
       if (prefs?.userNotes != null && prefs!.userNotes!.isNotEmpty) {
         _notesController.text = prefs.userNotes!;
       }

--- a/lib/widgets/exercise_card.dart
+++ b/lib/widgets/exercise_card.dart
@@ -63,6 +63,7 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
   late Animation<double> _expandAnimation;
   ExerciseSessionRecord? _lastSession;
   double? _allTimePR;
+  String? _userNotes;
 
   @override
   void initState() {
@@ -80,6 +81,7 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
     _expandController.value = _isExpanded ? 1.0 : 0.0;
 
     _loadExerciseHistory();
+    _loadUserNotes();
   }
 
   // Return whether the card is currently expanded.
@@ -101,6 +103,17 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
       _isExpanded = false;
       _expandController.reverse();
     });
+  }
+
+  /// Load user notes from preferences
+  Future<void> _loadUserNotes() async {
+    final repo = ref.read(exerciseRepositoryProvider);
+    var notes = (await repo.getPreferenceForExercise(
+      widget.exercise.exercise.id,
+    ))?.userNotes;
+    if (mounted && notes != null) {
+      setState(() => _userNotes = notes);
+    }
   }
 
   /// Load exercise history data (last session and PR)
@@ -557,8 +570,9 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Exercise Notes (if any)
-          if (widget.exercise.notes?.isNotEmpty == true) ...[
+          // Exercise Notes — prefer user notes, fall back to exercise notes
+          if ((_userNotes?.isNotEmpty ?? false) ||
+              (widget.exercise.notes?.isNotEmpty == true)) ...[
             Container(
               width: double.infinity,
               padding: const EdgeInsets.all(AppSpacing.sm),
@@ -569,7 +583,9 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
                 ),
               ),
               child: MarkdownBody(
-                data: widget.exercise.notes!,
+                data: _userNotes?.isNotEmpty == true
+                    ? _userNotes!
+                    : widget.exercise.notes!,
                 selectable: true,
                 styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
                     .copyWith(
@@ -776,7 +792,8 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
   }
 
   /// Shows a modal bottom sheet with detailed information about the exercise.
-  void _showExerciseDetails(BuildContext context) {
-    ExerciseDetailBottomSheet.show(context, widget.exercise.exercise);
+  Future<void> _showExerciseDetails(BuildContext context) async {
+    await ExerciseDetailBottomSheet.show(context, widget.exercise.exercise);
+    _loadUserNotes();
   }
 }

--- a/lib/widgets/exercise_card.dart
+++ b/lib/widgets/exercise_card.dart
@@ -108,11 +108,19 @@ class _ExerciseCardState extends ConsumerState<ExerciseCard>
   /// Load user notes from preferences
   Future<void> _loadUserNotes() async {
     final repo = ref.read(exerciseRepositoryProvider);
-    var notes = (await repo.getPreferenceForExercise(
-      widget.exercise.exercise.id,
-    ))?.userNotes;
-    if (mounted && notes != null) {
-      setState(() => _userNotes = notes);
+    try {
+      final preference = await repo.getPreferenceForExercise(
+        widget.exercise.exercise.id,
+      );
+      if (!mounted) return;
+      setState(() {
+        _userNotes = preference?.userNotes;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _userNotes = null;
+      });
     }
   }
 

--- a/lib/widgets/exercise_detail_content.dart
+++ b/lib/widgets/exercise_detail_content.dart
@@ -171,8 +171,7 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
       if (mounted) {
         setState(() {
           _preferences = prefs;
-          _userNotesController.text =
-              prefs?.userNotes ?? widget.exercise.notes ?? '';
+          _userNotesController.text = prefs?.userNotes ?? '';
           _isLoadingPreferences = false;
         });
       }

--- a/lib/widgets/exercise_detail_content.dart
+++ b/lib/widgets/exercise_detail_content.dart
@@ -171,7 +171,8 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
       if (mounted) {
         setState(() {
           _preferences = prefs;
-          _userNotesController.text = prefs?.userNotes ?? '';
+          _userNotesController.text =
+              prefs?.userNotes ?? widget.exercise.notes ?? '';
           _isLoadingPreferences = false;
         });
       }
@@ -384,14 +385,7 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
         // Instructions Section
         _buildInstructionsSection(),
 
-        // Notes Section (quick tips from exercise)
-        if (widget.exercise.notes != null &&
-            widget.exercise.notes!.isNotEmpty) ...[
-          const VSpace.xl(),
-          _buildNotesSection(),
-        ],
-
-        // User Notes Section (always shown for editing)
+        // Notes Section (always shown for editing)
         const VSpace.xl(),
         _buildUserNotesSection(),
 
@@ -988,7 +982,11 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
     );
   }
 
-  Widget _buildNotesSection() {
+  Widget _buildUserNotesSection() {
+    final hasNotes =
+        (_preferences?.userNotes?.isNotEmpty ?? false) ||
+        (widget.exercise.notes?.isNotEmpty ?? false);
+
     return AppCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1001,50 +999,9 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
                 size: AppDimensions.iconMedium,
               ),
               const HSpace.sm(),
-              Text(
-                'Exercise Tips',
-                style: AppTextStyles.titleSmall.copyWith(
-                  color: context.textPrimary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-          const VSpace.md(),
-          MarkdownBody(
-            data: widget.exercise.notes!,
-            selectable: true,
-            styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context))
-                .copyWith(
-                  p: AppTextStyles.bodyMedium.copyWith(
-                    color: context.textSecondary,
-                    height: 1.6,
-                  ),
-                ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildUserNotesSection() {
-    final hasNotes = _preferences?.userNotes?.isNotEmpty ?? false;
-
-    return AppCard(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              HugeIcon(
-                icon: HugeIcons.strokeRoundedEdit01,
-                color: context.warningColor,
-                size: AppDimensions.iconMedium,
-              ),
-              const HSpace.sm(),
               Expanded(
                 child: Text(
-                  'My Notes',
+                  'Notes',
                   style: AppTextStyles.titleSmall.copyWith(
                     color: context.textPrimary,
                     fontWeight: FontWeight.w600,
@@ -1104,7 +1061,8 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
             if (_isEditingNotes) ...[
               TextButton(
                 onPressed: () {
-                  _userNotesController.text = _preferences?.userNotes ?? '';
+                  _userNotesController.text =
+                      _preferences?.userNotes ?? widget.exercise.notes ?? '';
                   setState(() => _isEditingNotes = false);
                   _notesFocusNode.unfocus();
                 },
@@ -1142,7 +1100,7 @@ class _ExerciseDetailContentState extends ConsumerState<ExerciseDetailContent> {
           borderRadius: BorderRadius.circular(AppDimensions.borderRadiusMedium),
         ),
         child: MarkdownBody(
-          data: _preferences?.userNotes ?? '',
+          data: _preferences?.userNotes ?? widget.exercise.notes ?? '',
           selectable: true,
           styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
             p: AppTextStyles.bodyMedium.copyWith(

--- a/test/data/repositories/exercise_repository_test.dart
+++ b/test/data/repositories/exercise_repository_test.dart
@@ -588,7 +588,7 @@ void main() {
           preferredReps: 5,
           preferredWeight: 225.0,
           preferredRestTimeSeconds: 180,
-          notes: 'Focus on form',
+          userNotes: 'Focus on form',
         );
       });
 
@@ -662,7 +662,6 @@ void main() {
             preferredSets: 5,
             preferredReps: 3,
             preferredWeight: 315.0,
-            notes: 'Heavy day',
           ),
         );
       });
@@ -675,7 +674,6 @@ void main() {
         expect(bench.defaultSets, equals(5));
         expect(bench.defaultReps, equals(3));
         expect(bench.defaultWeight, equals(315.0));
-        expect(bench.notes, equals('Heavy day'));
       });
 
       test(

--- a/test/models/user_exercise_preferences_test.dart
+++ b/test/models/user_exercise_preferences_test.dart
@@ -36,7 +36,7 @@ void main() {
         expect(pref.preferredReps, isNull);
         expect(pref.preferredWeight, isNull);
         expect(pref.preferredRestTimeSeconds, isNull);
-        expect(pref.notes, isNull);
+        expect(pref.userNotes, isNull);
       });
 
       test('should create with all optional fields', () {
@@ -47,7 +47,7 @@ void main() {
           preferredReps: 5,
           preferredWeight: 225.0,
           preferredRestTimeSeconds: 180,
-          notes: 'Heavy day',
+          userNotes: 'Heavy day',
           createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         );
@@ -56,7 +56,7 @@ void main() {
         expect(pref.preferredReps, equals(5));
         expect(pref.preferredWeight, equals(225.0));
         expect(pref.preferredRestTimeSeconds, equals(180));
-        expect(pref.notes, equals('Heavy day'));
+        expect(pref.userNotes, equals('Heavy day'));
       });
     });
 
@@ -99,7 +99,7 @@ void main() {
         expect(pref.preferredReps, isNull);
         expect(pref.preferredWeight, isNull);
         expect(pref.preferredRestTimeSeconds, isNull);
-        expect(pref.notes, isNull);
+        expect(pref.userNotes, isNull);
       });
     });
 
@@ -146,10 +146,10 @@ void main() {
         expect(pref.hasPreferences, isTrue);
       });
 
-      test('should return true when notes is set', () {
+      test('should return true when userNotes is set', () {
         final pref = UserExercisePreferences.create(
           exerciseId: 'bench',
-          notes: 'Some notes',
+          userNotes: 'Some notes',
         );
 
         expect(pref.hasPreferences, isTrue);
@@ -215,15 +215,16 @@ void main() {
         expect(modified.defaultRestTimeSeconds, equals(180));
       });
 
-      test('should apply notes to exercise', () {
+      test('should not apply userNotes to exercise notes', () {
         final pref = UserExercisePreferences.create(
           exerciseId: 'bench',
-          notes: 'Focus on form',
+          userNotes: 'Focus on form',
         );
 
         final modified = pref.applyToExercise(testExercise);
 
-        expect(modified.notes, equals('Focus on form'));
+        // userNotes are stored separately in preferences, not on the exercise
+        expect(modified.notes, equals(testExercise.notes));
       });
 
       test('should apply all preferences at once', () {
@@ -233,7 +234,7 @@ void main() {
           preferredReps: 5,
           preferredWeight: 315.0,
           preferredRestTimeSeconds: 240,
-          notes: 'Heavy day',
+          userNotes: 'Heavy day',
         );
 
         final modified = pref.applyToExercise(testExercise);
@@ -242,7 +243,8 @@ void main() {
         expect(modified.defaultReps, equals(5));
         expect(modified.defaultWeight, equals(315.0));
         expect(modified.defaultRestTimeSeconds, equals(240));
-        expect(modified.notes, equals('Heavy day'));
+        // userNotes are stored separately in preferences, not on the exercise
+        expect(modified.notes, equals(testExercise.notes));
       });
 
       test('should not modify original exercise', () {
@@ -298,7 +300,7 @@ void main() {
           preferredReps: 5,
           preferredWeight: 225.0,
           preferredRestTimeSeconds: 120,
-          notes: 'Original notes',
+          userNotes: 'Original notes',
         );
       });
 
@@ -330,9 +332,9 @@ void main() {
       });
 
       test('should create copy with updated notes', () {
-        final copy = originalPref.copyWith(notes: 'Updated notes');
+        final copy = originalPref.copyWith(userNotes: 'Updated notes');
 
-        expect(copy.notes, equals('Updated notes'));
+        expect(copy.userNotes, equals('Updated notes'));
       });
 
       test('should preserve id when copying', () {
@@ -386,7 +388,7 @@ void main() {
           preferredReps: 5,
           preferredWeight: 225.0,
           preferredRestTimeSeconds: 120,
-          notes: 'Test notes',
+          userNotes: 'Test notes',
           createdAt: DateTime.utc(2025, 1, 1, 12, 0, 0),
           updatedAt: DateTime.utc(2025, 1, 2, 12, 0, 0),
         );
@@ -399,7 +401,7 @@ void main() {
         expect(json['preferredReps'], equals(5));
         expect(json['preferredWeight'], equals(225.0));
         expect(json['preferredRestTimeSeconds'], equals(120));
-        expect(json['notes'], equals('Test notes'));
+        expect(json['userNotes'], equals('Test notes'));
         expect(json['createdAt'], isNotNull);
         expect(json['updatedAt'], isNotNull);
       });
@@ -412,7 +414,7 @@ void main() {
           'preferredReps': 5,
           'preferredWeight': 225.0,
           'preferredRestTimeSeconds': 120,
-          'notes': 'Test notes',
+          'userNotes': 'Test notes',
           'createdAt': '2025-01-01T12:00:00.000Z',
           'updatedAt': '2025-01-02T12:00:00.000Z',
         };
@@ -425,7 +427,7 @@ void main() {
         expect(pref.preferredReps, equals(5));
         expect(pref.preferredWeight, equals(225.0));
         expect(pref.preferredRestTimeSeconds, equals(120));
-        expect(pref.notes, equals('Test notes'));
+        expect(pref.userNotes, equals('Test notes'));
       });
 
       test('fromJson should handle null optional fields', () {
@@ -442,7 +444,7 @@ void main() {
         expect(pref.preferredReps, isNull);
         expect(pref.preferredWeight, isNull);
         expect(pref.preferredRestTimeSeconds, isNull);
-        expect(pref.notes, isNull);
+        expect(pref.userNotes, isNull);
       });
 
       test('round-trip serialization should preserve data', () {
@@ -450,7 +452,7 @@ void main() {
           exerciseId: 'bench',
           preferredSets: 5,
           preferredWeight: 225.0,
-          notes: 'Round trip test',
+          userNotes: 'Round trip test',
         );
 
         final json = original.toJson();
@@ -460,7 +462,7 @@ void main() {
         expect(restored.exerciseId, equals(original.exerciseId));
         expect(restored.preferredSets, equals(original.preferredSets));
         expect(restored.preferredWeight, equals(original.preferredWeight));
-        expect(restored.notes, equals(original.notes));
+        expect(restored.userNotes, equals(original.userNotes));
       });
     });
   });


### PR DESCRIPTION
This pull request refactors the handling of exercise notes in the user preferences model and throughout the app. The main change is the removal of the `notes` field from `UserExercisePreferences`, consolidating all user-specific notes into the `userNotes` field. The UI is updated to consistently show a unified "Notes" section, prioritizing user notes if available and falling back to exercise notes otherwise. Associated logic, test cases, and serialization are updated to reflect this change.

**Model and Data Layer Refactor:**

* Removed the `notes` field from the `UserExercisePreferences` model, constructors, methods, serialization/deserialization, and replaced all usages with `userNotes`. [[1]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL30-L32) [[2]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL59) [[3]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL77) [[4]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL91) [[5]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL107) [[6]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL135) [[7]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL153) [[8]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL169) [[9]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL221) [[10]](diffhunk://#diff-9bdcf8e34871e758c1deb8d7d31d289e3866b303a53fe8d2c20a88f2f255156bL256)
* Updated repository tests to use `userNotes` instead of `notes` and removed assertions related to `notes`. [[1]](diffhunk://#diff-ff30d5121b86137f0d240f13aeb594c2d807a81cf1adf73780ad28cc73c59877L591-R591) [[2]](diffhunk://#diff-ff30d5121b86137f0d240f13aeb594c2d807a81cf1adf73780ad28cc73c59877L665) [[3]](diffhunk://#diff-ff30d5121b86137f0d240f13aeb594c2d807a81cf1adf73780ad28cc73c59877L678)
* Updated model tests to check `userNotes` instead of `notes`. [[1]](diffhunk://#diff-f287a1dc35ebceebc937f02f490656fc756d78d2bcc3cfb6eb2165574b723203L39-R39) [[2]](diffhunk://#diff-f287a1dc35ebceebc937f02f490656fc756d78d2bcc3cfb6eb2165574b723203L50-R50) [[3]](diffhunk://#diff-f287a1dc35ebceebc937f02f490656fc756d78d2bcc3cfb6eb2165574b723203L59-R59)

**UI and User Experience Improvements:**

* In the exercise creation and detail screens, the notes field is now populated from `userNotes` if available, otherwise from exercise notes, ensuring a unified notes experience for users. [[1]](diffhunk://#diff-b8035ca5c11b525a1aa877ff0b27173ce4af9edec37e61821b753d9349f9362eR117-R123) [[2]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL174-R175) [[3]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL1107-R1065)
* Updated the exercise card widget to load and display user notes if present, falling back to exercise notes, and refresh notes after detail modal interactions. [[1]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efR66) [[2]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efR84) [[3]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efR108-R118) [[4]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efL560-R575) [[5]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efL572-R588) [[6]](diffhunk://#diff-df39e0007cf6b2b4649b1c1da62e467b2096f7eb51fc2ee6edc6f8ec7ed3a8efL779-R797)

**Notes Section Consolidation:**

* Removed the separate "Exercise Tips" section from the detail view and merged it into a single "Notes" section, which now displays user notes or exercise notes as appropriate. [[1]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL387-R388) [[2]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL991-R988) [[3]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL1040-R1004) [[4]](diffhunk://#diff-aa944ec25b2bfe605fab994367b59fbebf158e93f442d89ef431e816bd312fbcL1145-R1103)

**Synchronization Logic:**

* Ensured that notes entered during exercise creation/editing are synced to user preferences, so they appear in the unified notes section in detail views.

**Documentation Update:**

* Updated documentation comments to clarify the distinction and usage of `userNotes`.